### PR TITLE
Script env var behavior alignment

### DIFF
--- a/bin/nodeCluster.sh
+++ b/bin/nodeCluster.sh
@@ -7,44 +7,124 @@
 # 
 # Copyright Contributors to the Zowe Project.
 
-export dir=`dirname "$0"`
-cd $dir
-
-export NODE_PATH=../../zlux-proxy-server/js/node_modules:$NODE_PATH
-cd ../js
-
-if [ -z "$ZLUX_NODE_LOG_DIR" ]
+if [ -n "$ZLUX_NODE_LOG_FILE" ]
 then
-  ZLUX_NODE_LOG_DIR="../log"
+  if [ -n "$ZLUX_NODE_LOG_DIR" ]
+  then
+    echo "ZLUX_NODE_LOG_FILE set (value $ZLUX_NODE_LOG_FILE).  Ignoring ZLUX_NODE_LOG_DIR."
+  fi
+else
+# _FILE was not specified; default filename, and check and maybe default _DIR
+  if [ -z "$ZLUX_NODE_LOG_DIR" ]
+  then
+    ZLUX_NODE_LOG_DIR="../log"
+  fi
+  
+  if [ -f "$ZLUX_NODE_LOG_DIR" ]
+  then
+    ZLUX_NODE_LOG_FILE=$ZLUX_NODE_LOG_DIR
+  elif [ ! -d "$ZLUX_NODE_LOG_DIR" ]
+  then
+    echo "Will make log directory $ZLUX_NODE_LOG_DIR"
+    mkdir -p $ZLUX_NODE_LOG_DIR
+    if [ $? -ne 0 ]
+    then
+      echo "Cannot make log directory.  Logging disabled."
+      ZLUX_NODE_LOG_FILE=/dev/null
+    fi
+  fi
+  
+  ZLUX_ROTATE_LOGS=0
+  if [ -d "$ZLUX_NODE_LOG_DIR" ] && [ -z "$ZLUX_NODE_LOG_FILE" ]
+  then
+    ZLUX_NODE_LOG_FILE="$ZLUX_NODE_LOG_DIR/nodeServer-`date +%Y-%m-%d-%H-%M`.log"
+    if [ -z "$ZLUX_NODE_LOGS_TO_KEEP" ]
+    then
+      ZLUX_NODE_LOGS_TO_KEEP=5
+    fi
+    echo $ZLUX_NODE_LOGS_TO_KEEP|egrep '^\-?[0-9]+$' >/dev/null
+    if [ $? -ne 0 ]
+    then
+      echo "ZLUX_NODE_LOGS_TO_KEEP not a number.  Defaulting to 5."
+      ZLUX_NODE_LOGS_TO_KEEP=5
+    fi
+    if [ $ZLUX_NODE_LOGS_TO_KEEP -ge 0 ]
+    then
+      ZLUX_ROTATE_LOGS=1
+    fi 
+  fi
+  
+  #Clean up excess logs, if appropriate.
+  if [ $ZLUX_ROTATE_LOGS -ne 0 ]
+  then
+    for f in `ls -r -1 $ZLUX_NODE_LOG_DIR/nodeServer-*.log 2>/dev/null | tail +$ZLUX_NODE_LOGS_TO_KEEP`
+    do
+      echo nodeServer.sh removing $f
+      rm -f $f
+    done
+  fi
 fi
 
-if [ -f "$ZLUX_NODE_LOG_DIR" ]
+ZLUX_NODE_CHECK_DIR="$(dirname "$ZLUX_NODE_LOG_FILE")"
+if [ ! -d "$ZLUX_NODE_CHECK_DIR" ]
 then
-  ZLUX_NODE_LOG_FILE="$ZLUX_NODE_LOG_DIR"
-  echo "Will log to file = ${ZLUX_NODE_LOG_FILE}"
-elif [ ! -d "$ZLUX_NODE_LOG_DIR" ]
+  echo "ZLUX_NODE_LOG_FILE contains nonexistent directories.  Creating $ZLUX_NODE_CHECK_DIR"
+  mkdir -p $ZLUX_NODE_CHECK_DIR
+  if [ $? -ne 0 ]
+  then
+    echo "Cannot make log directory.  Logging disabled."
+    ZLUX_NODE_LOG_FILE=/dev/null
+  fi
+fi
+#Now sanitize final log filename: if it is relative, make it absolute before cd to js
+if [ "$ZLUX_NODE_LOG_FILE" != "/dev/null" ]
 then
-  echo "Will make log directory $ZLUX_NODE_LOG_DIR"
-  mkdir -p $ZLUX_NODE_LOG_DIR
+  ZLUX_NODE_CHECK_DIR=$(cd "$(dirname "$ZLUX_NODE_LOG_FILE")"; pwd)
+  ZLUX_NODE_LOG_FILE=$ZLUX_NODE_CHECK_DIR/$(basename "$ZLUX_NODE_LOG_FILE")
 fi
 
-if [ -d "$ZLUX_NODE_LOG_DIR" ]
-then
-  ZLUX_NODE_LOG_FILE="$ZLUX_NODE_LOG_DIR/nodeServer.log"
-fi
-
-if [ ! -e $ZLUX_NODE_LOG_FILE && "$ZLUX_NODE_LOG_FILE" != "/dev/null" ]
-then
-  touch $ZLUX_NODE_LOG_FILE
-fi
 
 echo ZLUX_NODE_LOG_FILE=${ZLUX_NODE_LOG_FILE}
+
+if [ ! -e $ZLUX_NODE_LOG_FILE ]
+then
+  touch $ZLUX_NODE_LOG_FILE
+  if [ $? -ne 0 ]
+  then
+    echo "Cannot make log file.  Logging disabled."
+    ZLUX_NODE_LOG_FILE=/dev/null
+  fi
+else
+  if [ -d $ZLUX_NODE_LOG_FILE ]
+  then
+    echo "ZLUX_NODE_LOG_FILE is a directory.  Must be a file.  Logging disabled."
+    ZLUX_NODE_LOG_FILE=/dev/null
+  fi
+fi
+
+if [ ! -w "$ZLUX_NODE_LOG_FILE" ]
+then
+  echo file "$ZLUX_NODE_LOG_FILE" is not writable. Logging disabled.
+  ZLUX_NODE_LOG_FILE=/dev/null
+fi
+
+#Determined log file.  Run node appropriately.
+export dir=`dirname "$0"`
+cd $dir
+export NODE_PATH=../../zlux-proxy-server/js/node_modules:$NODE_PATH
+cd ../js
 
 if [ -n "$NODE_HOME" ]
 then
   export PATH=$NODE_HOME/bin:$PATH
 else
   echo WARN- NODE_HOME environment variable not defined, not setting PATH
+fi
+
+if [ -z `command -v node` ]
+then
+  echo "Node not found in path. Please ensure NODE_HOME variable is properly set"
+  exit 1
 fi
 
 export "_CEE_RUNOPTS=XPLINK(ON),HEAPPOOLS(ON)"
@@ -59,13 +139,8 @@ which node
 
 echo Starting node
 
-if [ ! -w "$ZLUX_NODE_LOG_FILE" && "$ZSS_NODE_LOG_FILE" != "/dev/null"  ]
-then
-  echo file "$ZLUX_NODE_LOG_FILE" is not writable. Exiting
-  exit 1
-else
-  node --harmony zluxCluster.js --config=../deploy/instance/ZLUX/serverConfig/zluxserver.json "$@" 2>&1 | tee $ZLUX_NODE_LOG_FILE
-fi
+node --harmony zluxCluster.js --config=../deploy/instance/ZLUX/serverConfig/zluxserver.json "$@" 2>&1 | tee $ZLUX_NODE_LOG_FILE
+
 
 
 # This program and the accompanying materials are

--- a/bin/nodeServer.sh
+++ b/bin/nodeServer.sh
@@ -68,7 +68,7 @@ fi
 ZLUX_NODE_CHECK_DIR="$(dirname "$ZLUX_NODE_LOG_FILE")"
 if [ ! -d "$ZLUX_NODE_CHECK_DIR" ]
 then
-  echo "ZLUX_NODE_LOG_FILE contains nonexistant directories.  Creating $ZLUX_NODE_CHECK_DIR"
+  echo "ZLUX_NODE_LOG_FILE contains nonexistent directories.  Creating $ZLUX_NODE_CHECK_DIR"
   mkdir -p $ZLUX_NODE_CHECK_DIR
   if [ $? -ne 0 ]
   then

--- a/bin/zssServer.sh
+++ b/bin/zssServer.sh
@@ -46,7 +46,7 @@ else
     fi
   fi
   
-  ZSS_ROTATE_LOGS=0
+  ZLUX_ROTATE_LOGS=0
   if [ -d "$ZSS_LOG_DIR" ] && [ -z "$ZSS_LOG_FILE" ]
   then
     ZSS_LOG_FILE="$ZSS_LOG_DIR/zssServer-`date +%Y-%m-%d-%H-%M`.log"
@@ -62,12 +62,12 @@ else
     fi
     if [ $ZSS_LOGS_TO_KEEP -ge 0 ]
     then
-      ZSS_ROTATE_LOGS=1
+      ZLUX_ROTATE_LOGS=1
     fi 
   fi
   
   #Clean up excess logs, if appropriate.
-  if [ $ZSS_ROTATE_LOGS -ne 0 ]
+  if [ $ZLUX_ROTATE_LOGS -ne 0 ]
   then
     for f in `ls -r -1 $ZSS_LOG_DIR/zssServer-*.log 2>/dev/null | tail +$ZSS_LOGS_TO_KEEP`
     do

--- a/bin/zssServer.sh
+++ b/bin/zssServer.sh
@@ -8,8 +8,19 @@
 # Copyright Contributors to the Zowe Project.
 ## launch the ZLUX secure services server
 
+ZSS_SCRIPT_DIR=$(cd `dirname $0` && pwd)                                      
+echo "pwd = `pwd`"                                                            
+echo "Script dir = $(cd `dirname $0` && pwd)"
+
 if [ -n "$ZSS_LOG_FILE" ]
 then
+  if [[ $ZSS_LOG_FILE == /* ]]                                                
+  then                                                                        
+    echo "Absolute log location given."                                                           
+  else                                                                        
+    ZSS_LOG_FILE="${ZSS_SCRIPT_DIR}/${ZSS_LOG_FILE}"                          
+    echo "Relative log location given, set to absolute path=$ZSS_LOG_FILE"                          
+  fi  
   if [ -n "$ZSS_LOG_DIR" ]
   then
     echo "ZSS_LOG_FILE set (value $ZSS_LOG_FILE).  Ignoring ZSS_LOG_DIR."
@@ -35,7 +46,7 @@ else
     fi
   fi
   
-  ZLUX_ROTATE_LOGS=0
+  ZSS_ROTATE_LOGS=0
   if [ -d "$ZSS_LOG_DIR" ] && [ -z "$ZSS_LOG_FILE" ]
   then
     ZSS_LOG_FILE="$ZSS_LOG_DIR/zssServer-`date +%Y-%m-%d-%H-%M`.log"
@@ -51,12 +62,12 @@ else
     fi
     if [ $ZSS_LOGS_TO_KEEP -ge 0 ]
     then
-      ZLUX_ROTATE_LOGS=1
+      ZSS_ROTATE_LOGS=1
     fi 
   fi
   
   #Clean up excess logs, if appropriate.
-  if [ $ZLUX_ROTATE_LOGS -ne 0 ]
+  if [ $ZSS_ROTATE_LOGS -ne 0 ]
   then
     for f in `ls -r -1 $ZSS_LOG_DIR/zssServer-*.log 2>/dev/null | tail +$ZSS_LOGS_TO_KEEP`
     do
@@ -69,7 +80,7 @@ fi
 ZSS_CHECK_DIR="$(dirname "$ZSS_LOG_FILE")"
 if [ ! -d "$ZSS_CHECK_DIR" ]
 then
-  echo "ZSS_LOG_FILE contains nonexistant directories.  Creating $ZSS_CHECK_DIR"
+  echo "ZSS_LOG_FILE contains nonexistent directories.  Creating $ZSS_CHECK_DIR"
   mkdir -p $ZSS_CHECK_DIR
   if [ $? -ne 0 ]
   then


### PR DESCRIPTION
Typo fix, plus making nodeCluster script behave as nodeServer script does, and fixing zssServer.sh such that the file env var utilizes the location of the script for relative path, to align to node script path behavior

Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>