### PR TITLE
Adding ipAddresses field for zlux and agent(zss) for specifying binding to specific IPs

### DIFF
--- a/config/zluxserver.json
+++ b/config/zluxserver.json
@@ -1,5 +1,6 @@
 {
   "node": {
+    "ipAddresses": ["0.0.0.0"],
     "https": {
       "port": 8544,
       //pfx (string), keys, certificates, certificateAuthorities, and certificateRevocationLists are all valid here.
@@ -24,6 +25,9 @@
         "once": true
       }
     ]
+  },
+  "agent": {
+    "ipAddresses": ["0.0.0.0"]
   },
 // All paths relative to ZLUX/node or ZLUX/bin
 // In real installations, these values will be configured during the install.


### PR DESCRIPTION
To better structure this config file, I'm putting the IP address specification that would be used for ZSS within an "agent" body, where I'd like zssPort to eventually be moved as http.port, or https.port.
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>